### PR TITLE
zendesk 231803: Fix missing retry case in search api

### DIFF
--- a/uploader/sumologic.js
+++ b/uploader/sumologic.js
@@ -172,9 +172,13 @@ const sumoSearch = async ({sumo, url: initUrl, payload}) => {
     const {status, data} = await sumoRequest({sumo, url: statusUrl});
     const {state, messageCount, recordCount} = data;
 
-    if (status >= 200 && status <= 299 && state === "DONE GATHERING RESULTS") {
-      console.log(`:: messageCount='${messageCount}' recordCount='${recordCount}'`);
-      return true;
+    if (status >= 200 && status <= 299) {
+      if (state === "DONE GATHERING RESULTS") {
+        console.log(`:: messageCount='${messageCount}' recordCount='${recordCount}'`);
+        return true;
+      } else if (state === "GATHERING RESULTS") {
+        return false;
+      }
     }
     if (status === 429) {
       console.log(`:: ${statusUrl} ${JSON.stringify({status, data}, null, 0)}`);


### PR DESCRIPTION
Fix a missing case when the search API should retry on 200 with "GATHERING RESULTS" state.

https://glghd.zendesk.com/agent/tickets/231804